### PR TITLE
4 datetime

### DIFF
--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 import pandas as pd
 
@@ -9,7 +9,7 @@ from manager.tools import get_last_friday_date, get_folder_name, make_results_fo
 from manager.cumulate_results import compute_cumulated_result
 
 
-def run_manager(base_url: str, selected: pd.DataFrame, run_date: datetime = datetime.now()):
+def run_manager(base_url: str, selected: pd.DataFrame, run_date: date = datetime.now().date()):
     draw_date, draw_date_str = get_last_friday_date(run_date)
     folder_name = get_folder_name(draw_date)
     folder_path = make_results_folder(folder_name)
@@ -25,14 +25,14 @@ def run_manager(base_url: str, selected: pd.DataFrame, run_date: datetime = date
     return results
 
 
-def get_draw_information(base_url: str, draw_date: datetime) -> (dict, dict):
+def get_draw_information(base_url: str, draw_date: date) -> (dict, dict):
     historical_data = scrape_historical_results(base_url)
     draw_result = extract_draw_result(draw_date, historical_data)
     prize_breakdown = scrape_prize_breakdown(base_url, draw_result['DrawNumber'])
     return draw_result, prize_breakdown
 
 
-def run_manager_between(base_url: str, selected: pd.DataFrame, start: datetime, end: datetime, freq: str = '7D'):
+def run_manager_between(base_url: str, selected: pd.DataFrame, start: date, end: date, freq: str = '7D'):
     for run_date in pd.date_range(start, end, freq=freq):
         run_manager(base_url, selected, run_date)
 

--- a/manager/scrape_results.py
+++ b/manager/scrape_results.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import date
 
 import requests
 from bs4 import BeautifulSoup as bSoup
@@ -26,7 +26,7 @@ def scrape_historical_results(base_url: str) -> pd.DataFrame:
     return pd.read_csv(link_to_csv)
 
 
-def extract_draw_result(draw_date: datetime, hist_results: pd.DataFrame) -> dict:
+def extract_draw_result(draw_date: date, hist_results: pd.DataFrame) -> dict:
     """ from historical results DataFrame extract the result information for the selected draw date. """
     hist_results['DrawDate'] = pd.to_datetime(hist_results['DrawDate'], format='%d-%b-%Y')
     draw_date_mask = hist_results['DrawDate'] == pd.to_datetime(draw_date)

--- a/manager/tools.py
+++ b/manager/tools.py
@@ -1,35 +1,35 @@
 import os
-from datetime import timedelta, datetime
+from datetime import timedelta, date
 
 import pandas as pd
 
 
-def get_last_friday_date(date: datetime) -> (datetime, str):
+def get_last_friday_date(run_date: date) -> (date, str):
     """ User only runs on fridays. Therefore, given any date, function determines the
         date which the last friday occurred on.
     """
-    weekday_num = date.isoweekday()
+    weekday_num = run_date.isoweekday()
     if weekday_num > 5:
         diff = weekday_num - 5
     elif weekday_num < 5:
         diff = 7 - (5 - weekday_num)
     else:
         diff = 0
-    last_fri = (date - timedelta(days=diff)).date()
+    last_fri = run_date - timedelta(days=diff)
     last_fri_str = f"Fri {last_fri:%d}" + f" {last_fri:%B}"[0:4] + f" {last_fri:%Y}"
     return last_fri, last_fri_str
 
 
-def get_folder_name(selected_date: datetime) -> str:
+def get_folder_name(selected_date: date) -> str:
     """
     organise generated results into date range folders within ../results_archive.
     `date_range_start(end)` provided by user.
     if selected_date > end_range then it goes in the folder that starts there.
     """
-    def date_to_str(date: datetime) -> str: return f"{date:%Y-%m-%d}"
+    def date_to_str(a_date: date) -> str: return f"{a_date:%Y-%m-%d}"
 
-    date_range_start = datetime(2020, 1, 10)
-    date_range_end = datetime(2030, 12, 31)
+    date_range_start = date(2020, 1, 10)
+    date_range_end = date(2030, 12, 31)
     date_range_df = pd.DataFrame({
         'start': pd.date_range(date_range_start, date_range_end, freq='28D'),
         'end': pd.date_range(date_range_start + timedelta(days=28), date_range_end + timedelta(days=28), freq='28D')

--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import date
 
 import pandas as pd
 
@@ -12,11 +12,11 @@ if __name__ == '__main__':
     selected_numbers = pd.read_excel('./Selected Numbers.xlsx', engine='openpyxl')
 
     # run_manager(base_url, selected_numbers)
-    # run_manager_between(base_url, selected_numbers, datetime(2020, 6, 27), datetime(2020, 12, 20))
+    run_manager_between(base_url, selected_numbers, date(2020, 6, 27), date(2020, 12, 20))
 
-    run_manager_between(base_url, selected_numbers, datetime(2020, 6, 27), datetime(2020, 10, 20))
-    selected_numbers = selected_numbers[selected_numbers['Name'] != 'Ole']
-    run_manager_between(base_url, selected_numbers, datetime(2020, 10, 24), datetime(2020, 12, 20))
+    # run_manager_between(base_url, selected_numbers, date(2020, 6, 27), date(2020, 10, 20))
+    # selected_numbers = selected_numbers[selected_numbers['Name'] != 'Ole']
+    # run_manager_between(base_url, selected_numbers, date(2020, 10, 24), date(2020, 12, 20))
 
     produce_cumulative_report()
 

--- a/tests/test_scrape_results.py
+++ b/tests/test_scrape_results.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from datetime import datetime
+from datetime import date
 
 from pytest import fixture, raises
 
@@ -89,22 +89,22 @@ def hist_data():
 
 
 def test_extract_draw_result_incorrect_date(hist_data):
-    draw_date = datetime(2020, 1, 15)
+    draw_date = date(2020, 1, 15)
     with raises(Exception, match=r'Selected draw_date: .* not in hist_results\[\"DrawDate\"\]'):
         extract_draw_result(draw_date, hist_data)
 
 
 def test_extract_draw_result_matches_multiple_dates(hist_data):
-    draw_date = datetime(2020, 12, 11)
+    draw_date = date(2020, 12, 11)
     with raises(Exception, match=r'Selected draw_date: .* maps to many in hist_results\[\"DrawDate\"\]'):
         extract_draw_result(draw_date, hist_data)
 
 
 def test_extract_draw_result_valid_date(hist_data):
-    draw_date = datetime(2020, 12, 15)
+    draw_date = date(2020, 12, 15)
 
     expected_result = {
-        'DrawDate': datetime(2020, 12, 15), 'Ball 1': 1, 'Ball 2': 3, 'Lucky Star 1': 5,
+        'DrawDate': date(2020, 12, 15), 'Ball 1': 1, 'Ball 2': 3, 'Lucky Star 1': 5,
         'UK Millionaire Maker': 'alpha', 'DrawNumber': 1966
     }
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import date
 
 import pytest
 
@@ -8,13 +8,13 @@ from manager.tools import get_last_friday_date, get_folder_name
 @pytest.mark.parametrize(
     'today, last_fri, last_fri_str',
     [
-        (datetime.datetime(2020, 12, 10), datetime.datetime(2020, 12, 4), 'Fri 04 Dec 2020'),
-        (datetime.datetime(2020, 12, 11), datetime.datetime(2020, 12, 11), 'Fri 11 Dec 2020'),
-        (datetime.datetime(2020, 12, 12), datetime.datetime(2020, 12, 11), 'Fri 11 Dec 2020'),
-        (datetime.datetime(2020, 12, 13), datetime.datetime(2020, 12, 11), 'Fri 11 Dec 2020'),
-        (datetime.datetime(2020, 12, 14), datetime.datetime(2020, 12, 11), 'Fri 11 Dec 2020'),
-        (datetime.datetime(2020, 12, 15), datetime.datetime(2020, 12, 11), 'Fri 11 Dec 2020'),
-        (datetime.datetime(2020, 12, 16), datetime.datetime(2020, 12, 11), 'Fri 11 Dec 2020')
+        (date(2020, 12, 10), date(2020, 12, 4), 'Fri 04 Dec 2020'),
+        (date(2020, 12, 11), date(2020, 12, 11), 'Fri 11 Dec 2020'),
+        (date(2020, 12, 12), date(2020, 12, 11), 'Fri 11 Dec 2020'),
+        (date(2020, 12, 13), date(2020, 12, 11), 'Fri 11 Dec 2020'),
+        (date(2020, 12, 14), date(2020, 12, 11), 'Fri 11 Dec 2020'),
+        (date(2020, 12, 15), date(2020, 12, 11), 'Fri 11 Dec 2020'),
+        (date(2020, 12, 16), date(2020, 12, 11), 'Fri 11 Dec 2020')
     ]
 )
 def test_get_fri_date_str(today, last_fri, last_fri_str):
@@ -22,18 +22,18 @@ def test_get_fri_date_str(today, last_fri, last_fri_str):
 
 
 @pytest.mark.parametrize(
-    'date, folder_name',
+    'a_date, folder_name',
     [
-        (datetime.date(2020, 2, 16), '2020-02-07__2020-03-06'),
-        (datetime.date(2020, 3, 23), '2020-03-06__2020-04-03'),
-        (datetime.date(2020, 6, 11), '2020-05-29__2020-06-26'),
-        (datetime.date(2020, 8, 21), '2020-07-24__2020-08-21'),
-        (datetime.date(2020, 9, 17), '2020-08-21__2020-09-18'),
-        (datetime.date(2020, 10, 4), '2020-09-18__2020-10-16'),
-        (datetime.date(2021, 11, 16), '2021-11-12__2021-12-10'),
-        (datetime.date(2021, 12, 5), '2021-11-12__2021-12-10'),
-        (datetime.date(2022, 4, 9), '2022-04-01__2022-04-29')
+        (date(2020, 2, 16), '2020-02-07__2020-03-06'),
+        (date(2020, 3, 23), '2020-03-06__2020-04-03'),
+        (date(2020, 6, 11), '2020-05-29__2020-06-26'),
+        (date(2020, 8, 21), '2020-07-24__2020-08-21'),
+        (date(2020, 9, 17), '2020-08-21__2020-09-18'),
+        (date(2020, 10, 4), '2020-09-18__2020-10-16'),
+        (date(2021, 11, 16), '2021-11-12__2021-12-10'),
+        (date(2021, 12, 5), '2021-11-12__2021-12-10'),
+        (date(2022, 4, 9), '2022-04-01__2022-04-29')
     ]
 )
-def test_get_folder_name(date, folder_name):
-    assert get_folder_name(date) == folder_name
+def test_get_folder_name(a_date, folder_name):
+    assert get_folder_name(a_date) == folder_name


### PR DESCRIPTION
Closes #4. Where possible use date over datetime, to avoid any confusion when asserting a date == something and date has time element which makes comparison fail.